### PR TITLE
Fix copying http request headers

### DIFF
--- a/lib/core/alice_http_client_adapter.dart
+++ b/lib/core/alice_http_client_adapter.dart
@@ -40,9 +40,9 @@ class AliceHttpClientAdapter {
       httpRequest.body = body;
     }
     httpRequest.time = DateTime.now();
-    Map<String, dynamic> headers = Map();
-    httpRequest.headers.forEach((header, value) {
-      headers[header] = value;
+    Map<String, String> headers = Map();
+    request.headers.forEach((header, values) {
+      headers[header] = values.toString();
     });
 
     httpRequest.headers = headers;


### PR DESCRIPTION
Resolves #17.

`httpRequest.headers` is empty here (since it was just initialized), we should probably copy the headers from `request.headers`.