### PR TITLE
Fix: Support repeated query parameter keys in curl generation and request display

### DIFF
--- a/lib/core/alice_dio_interceptor.dart
+++ b/lib/core/alice_dio_interceptor.dart
@@ -74,7 +74,14 @@ class AliceDioInterceptor extends InterceptorsWrapper {
     request.time = DateTime.now();
     request.headers = options.headers;
     request.contentType = options.contentType.toString();
-    request.queryParameters = options.uri.queryParameters;
+    // Use queryParametersAll to preserve repeated keys (e.g. ?key=a&key=b).
+    // Flatten single-element lists back to plain strings for cleaner display.
+    final allParams = options.uri.queryParametersAll;
+    final flatParams = <String, dynamic>{};
+    allParams.forEach((key, values) {
+      flatParams[key] = values.length == 1 ? values.first : values;
+    });
+    request.queryParameters = flatParams;
 
     call.request = request;
     call.response = AliceHttpResponse();

--- a/lib/model/alice_http_call.dart
+++ b/lib/model/alice_http_call.dart
@@ -70,10 +70,19 @@ class AliceHttpCall {
       var queryParams = request?.queryParameters;
       if (queryParams != null && queryParams.isNotEmpty) {
         query += "?";
-        query += queryParams.entries
-            .map((e) =>
-                '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}')
-            .join('&');
+        final parts = <String>[];
+        queryParams.forEach((key, value) {
+          final encodedKey = Uri.encodeComponent(key);
+          if (value is List) {
+            // Expand list values into repeated keys: key=a&key=b
+            for (final item in value) {
+              parts.add('$encodedKey=${Uri.encodeComponent(item.toString())}');
+            }
+          } else {
+            parts.add('$encodedKey=${Uri.encodeComponent(value.toString())}');
+          }
+        });
+        query += parts.join('&');
       }
     }
 

--- a/lib/model/alice_http_request.dart
+++ b/lib/model/alice_http_request.dart
@@ -10,6 +10,7 @@ class AliceHttpRequest {
   dynamic body = "";
   String? contentType = "";
   List<Cookie> cookies = [];
+  /// Query parameters — values can be [String] or [List<String>] for repeated keys.
   Map<String, dynamic> queryParameters = Map();
   List<AliceFormDataFile>? formDataFiles;
   List<AliceFormDataField>? formDataFields;

--- a/lib/ui/widget/alice_call_request_widget.dart
+++ b/lib/ui/widget/alice_call_request_widget.dart
@@ -61,7 +61,6 @@ class _AliceCallRequestWidget
       rows.add(getListRow("   • $header:", value.toString()));
     });
 
-    print("qr: ${_request.queryParameters}");
     var queryParameters = _request.queryParameters;
     var queryParametersContent = "Query parameters are empty";
     if (queryParameters.length > 0) {
@@ -69,7 +68,14 @@ class _AliceCallRequestWidget
     }
     rows.add(getListRow("Query Parameters: ", queryParametersContent));
     _request.queryParameters.forEach((query, value) {
-      rows.add(getListRow("   • $query:", value.toString()));
+      if (value is List) {
+        // Display each value on its own row for repeated keys
+        for (final item in value) {
+          rows.add(getListRow("   • $query:", item.toString()));
+        }
+      } else {
+        rows.add(getListRow("   • $query:", value.toString()));
+      }
     });
 
     return Container(


### PR DESCRIPTION
  **Summary:**                                                                                                                                                                                                               

 When query parameters contain repeated keys (e.g. ?tag=foo&tag=bar), Alice previously only captured the last value because Uri.queryParameters returns a Map<String, String> which overwrites duplicate keys.          
                                                                                                                                                                                                                         
  **Changes:**                                                                                                                                                                                                               
                                                                                                                                                                                                                         
  - alice_dio_interceptor.dart: Use Uri.queryParametersAll instead of Uri.queryParameters to preserve all values for repeated keys. Single-value lists are flattened to plain strings for backward compatibility.        
  - alice_http_call.dart: Update getCurlCommand() to detect List values in query parameters and expand them into repeated keys (key=a&key=b) instead of serializing the list as a single value.                          
  - alice_call_request_widget.dart: Update the query parameters UI to display each value on its own row when a key has multiple values. Removed stray print() statement.                                                 
  - alice_http_request.dart: Updated doc comment on queryParameters to clarify values can be String or List<String>.                                                                                                     
                                              
  **Example:**                                                                                                                                                                                                               
                                                                      
  Before: curl ... '...?category=electronics' (only last value)                                                                                                                                                          
                                                                      
  After: curl ... '...?category=electronics&category=books&category=toys' (all values)       